### PR TITLE
Middleware exclude_paths option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ The middleware will add a `vsi-stats` entrie in the response headers in form of:
 vsi-stats: list;count=1, head;count=1, get;count=2;size=196608, ranges; values=0-65535|65536-196607
 ```
 
+Some paths may be excluded from being handeld by the middleware by the `exclude_paths` argument:
+
+```python
+app.add_middleware(VSIStatsMiddleware, exclude_paths=["/foo", "/bar"])
+```
+
 ## Command Line Interface (CLI)
 
 ```

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -32,6 +32,7 @@ def test_viz():
     response = client.get("/info.geojson")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/geo+json"
+    assert "VSI-Stats" not in response.headers
 
     response = client.get("/tiles.geojson?ovr_level=0")
     assert response.status_code == 200

--- a/tilebench/middleware.py
+++ b/tilebench/middleware.py
@@ -2,7 +2,7 @@
 
 import logging
 from io import StringIO
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import rasterio
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -16,13 +16,22 @@ from tilebench import analyse_logs
 class VSIStatsMiddleware(BaseHTTPMiddleware):
     """MiddleWare to add VSI stats in response headers."""
 
-    def __init__(self, app: ASGIApp, config: Optional[Dict] = None) -> None:
+    def __init__(
+        self,
+        app: ASGIApp,
+        config: Optional[Dict] = None,
+        exclude_paths: Optional[List] = None,
+    ) -> None:
         """Init Middleware."""
         super().__init__(app)
         self.config: Dict = config or {}
+        self.exclude_paths: List = exclude_paths or []
 
     async def dispatch(self, request: Request, call_next):
         """Add VSI stats in headers."""
+
+        if request.scope["path"] in self.exclude_paths:
+            return await call_next(request)
 
         rio_stream = StringIO()
         logger = logging.getLogger("rasterio")

--- a/tilebench/viz.py
+++ b/tilebench/viz.py
@@ -81,7 +81,9 @@ class TileDebug:
         self.register_routes()
         self.app.include_router(self.router)
         self.app.mount("/static", StaticFiles(directory=static_dir), name="static")
-        self.app.add_middleware(VSIStatsMiddleware, config=self.config)
+        self.app.add_middleware(
+            VSIStatsMiddleware, config=self.config, exclude_paths=["/info.geojson"]
+        )
         self.app.add_middleware(NoCacheMiddleware)
 
     def register_routes(self):


### PR DESCRIPTION
In my case `tilebench viz` hangs if `/info.geojson` is handled by the middleware and in general I think it is nice to have a way to disable some paths.