### PR TITLE
update rio-tiler and allow GDAL Timings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -53,9 +53,9 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.LATEST_PY_VERSION }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
 
+## 0.10.0 (2023-06-02)
+
+* update `rio-tiler` requirement
+* fix log parsing when `CPL_TIMESTAMP=ON` is set
+
 ## 0.9.1 (2023-03-24)
 
 * handle dateline crossing dataset and remove pydantic serialization

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ app.add_middleware(VSIStatsMiddleware, exclude_paths=["/foo", "/bar"])
 
 ## GDAL config options
 
+- **CPL_TIMESTAMP**: Add timings on GDAL Logs
 - **GDAL_DISABLE_READDIR_ON_OPEN**: Allow or Disable listing of files in the directory (e.g external overview)
 - **GDAL_INGESTED_BYTES_AT_OPEN**: Control how many bytes GDAL will ingest when opening a dataset (useful when a file has a big header)
 - **CPL_VSIL_CURL_ALLOWED_EXTENSIONS**: Limit valid external files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "geojson-pydantic",
     "loguru",
     "rasterio>=1.3.0",
-    "rio-tiler>=4.0.0a0,<5.0",
+    "rio-tiler>=4.0,<6.0",
     "wurlitzer",
     "uvicorn[standard]",
 ]

--- a/tilebench/__init__.py
+++ b/tilebench/__init__.py
@@ -41,7 +41,10 @@ def parse_logs(rio_lines: List[str], curl_lines: List[str]) -> Dict[str, Any]:
     # Rasterio GET
     # Rasterio only log successfull requests
     get_requests = [line for line in rio_lines if ": Downloading" in line]
-    get_values = [map(int, get.split(" ")[4].split("-")) for get in get_requests]
+    get_values = [
+        map(int, get.split(" Downloading ")[1].split(" ")[0].split("-"))
+        for get in get_requests
+    ]
     get_values_str = [get.split(" ")[4] for get in get_requests]
     data_transfer = sum([j - i + 1 for i, j in get_values])
 


### PR DESCRIPTION
```
tilebench profile https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif --tile 15-9114-13215 --add-cprofile --add-stdout --config GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR --config CPL_TIMESTAMP=ON | jq
{
  "LIST": {
    "count": 0
  },
  "HEAD": {
    "count": 1
  },
  "GET": {
    "count": 2,
    "bytes": 409600,
    "ranges": [
      "",
      ""
    ]
  },
  "Timing": 1.4050970077514648,
  "cprofile": [
    "   ncalls  tottime  percall  cumtime  percall filename:lineno(function)",
    "        1    0.867    0.867    0.869    0.869 __init__.py:108(open)",
    "        1    0.456    0.456    0.458    0.458 {method 'read' of 'rasterio._warp.WarpedVRTReaderBase' objects}",
    "        1    0.005    0.005    0.006    0.006 {rasterio._warp._calculate_default_transform}",
    "        2    0.004    0.002    0.004    0.002 {rasterio._warp._transform_bounds}",
    "      116    0.002    0.000    0.003    0.000 hooks.py:454(_alias_event_name)",
    "        1    0.002    0.002    0.464    0.464 reader.py:80(read)",
    "        1    0.002    0.002    0.002    0.002 {method 'close' of 'rasterio._base.DatasetBase' objects}",
    "        1    0.002    0.002    0.002    0.002 {method 'start' of 'rasterio._env.GDALEnv' objects}",
    "        1    0.001    0.001    0.002    0.002 core.py:3433(__setmask__)",
    "   495/10    0.001    0.000    0.001    0.000 {built-in method _abc._abc_subclasscheck}",
    "     5558    0.001    0.000    0.001    0.000 {method 'index' of 'list' objects}",
    "       77    0.001    0.000    0.003    0.000 __init__.py:282(__init__)",
    "        3    0.001    0.000    0.001    0.000 configparser.py:996(_read)",
    "        1    0.001    0.001    0.001    0.001 {method 'overviews' of 'rasterio._base.DatasetBase' objects}",
    "        3    0.001    0.000    0.001    0.000 {rasterio.crs.from_wkt}",
    "     7008    0.001    0.000    0.001    0.000 {method 'split' of 'str' objects}"
  ],
  "curl": [
    "* Couldn't find host noaa-eri-pds.s3.amazonaws.com in the (nil) file; using defaults",
    "*   Trying 3.5.6.217:443...",
    "* Connected to noaa-eri-pds.s3.amazonaws.com (3.5.6.217) port 443 (#0)",
    "* ALPN: offers h2",
    "* ALPN: offers http/1.1",
    "*  CAfile: /Users/vincentsarago/Dev/venv/py39/lib/python3.9/site-packages/certifi/cacert.pem",
    "*  CApath: none",
    "* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256",
    "* ALPN: server accepted http/1.1",
    "* Server certificate:",
    "*  subject: CN=*.s3.amazonaws.com",
    "*  start date: Mar 21 00:00:00 2023 GMT",
    "*  expire date: Dec 19 23:59:59 2023 GMT",
    "*  subjectAltName: host \"noaa-eri-pds.s3.amazonaws.com\" matched cert's \"*.s3.amazonaws.com\"",
    "*  issuer: C=US; O=Amazon; CN=Amazon RSA 2048 M01",
    "*  SSL certificate verify ok.",
    "> HEAD /2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif HTTP/1.1",
    "Host: noaa-eri-pds.s3.amazonaws.com",
    "Accept: */*",
    "",
    "* Mark bundle as not supporting multiuse",
    "< HTTP/1.1 200 OK",
    "< x-amz-id-2: d0XQz73eeBKy0KnnESGbXx5umIqdyBsw+iRW+Z8lUTLtswqiIpfIgwUnO1oHQtmKjTlsrhgJhLc4Fj/vG08MgA==",
    "< x-amz-request-id: SY7KPA3D9D1R4QDR",
    "< Date: Fri, 02 Jun 2023 16:44:52 GMT",
    "< Last-Modified: Sun, 02 Oct 2022 21:19:03 GMT",
    "< ETag: \"f22335a25b06f4f2b93f91a4a58e8324-15\"",
    "< Accept-Ranges: bytes",
    "< Content-Type: image/tiff",
    "< Server: AmazonS3",
    "< Content-Length: 119799105",
    "< ",
    "* Connection #0 to host noaa-eri-pds.s3.amazonaws.com left intact",
    "* Couldn't find host noaa-eri-pds.s3.amazonaws.com in the (nil) file; using defaults",
    "* Found bundle for host: 0x14275b810 [serially]",
    "* Can not multiplex, even if we wanted to",
    "* Re-using existing connection #0 with host noaa-eri-pds.s3.amazonaws.com",
    "> GET /2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif HTTP/1.1",
    "Host: noaa-eri-pds.s3.amazonaws.com",
    "Accept: */*",
    "Range: bytes=0-32767",
    "",
    "* Mark bundle as not supporting multiuse",
    "< HTTP/1.1 206 Partial Content",
    "< x-amz-id-2: nf9wJTrlCHVJoQmePUYr80jQmoP0VUgPsHD8ws0MTwsogBL/6bXQ0WFpNgB2sGQ509NzHuyzgP1+VX2Dvc9P0A==",
    "< x-amz-request-id: SY7Q5HSPBYYGJ14Y",
    "< Date: Fri, 02 Jun 2023 16:44:52 GMT",
    "< Last-Modified: Sun, 02 Oct 2022 21:19:03 GMT",
    "< ETag: \"f22335a25b06f4f2b93f91a4a58e8324-15\"",
    "< Accept-Ranges: bytes",
    "< Content-Range: bytes 0-32767/119799105",
    "< Content-Type: image/tiff",
    "< Server: AmazonS3",
    "< Content-Length: 32768",
    "< ",
    "* Connection #0 to host noaa-eri-pds.s3.amazonaws.com left intact",
    "* Couldn't find host noaa-eri-pds.s3.amazonaws.com in the (nil) file; using defaults",
    "* Found bundle for host: 0x14275b810 [serially]",
    "* Can not multiplex, even if we wanted to",
    "* Re-using existing connection #0 with host noaa-eri-pds.s3.amazonaws.com",
    "> GET /2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif HTTP/1.1",
    "Host: noaa-eri-pds.s3.amazonaws.com",
    "Accept: */*",
    "Range: bytes=32768-409599",
    "",
    "* Mark bundle as not supporting multiuse",
    "< HTTP/1.1 206 Partial Content",
    "< x-amz-id-2: 0a6hEZ+6sAn+eCjTKTytlGi81SoxQuvNKMZw9zH5u06Jd1edBj93zpLLRAh/FwsWFZqU/ArMnpiW5jHztqlj2g==",
    "< x-amz-request-id: SY7KSGN4S6CA7CNM",
    "< Date: Fri, 02 Jun 2023 16:44:52 GMT",
    "< Last-Modified: Sun, 02 Oct 2022 21:19:03 GMT",
    "< ETag: \"f22335a25b06f4f2b93f91a4a58e8324-15\"",
    "< Accept-Ranges: bytes",
    "< Content-Range: bytes 32768-409599/119799105",
    "< Content-Type: image/tiff",
    "< Server: AmazonS3",
    "< Content-Length: 376832",
    "< ",
    "* Connection #0 to host noaa-eri-pds.s3.amazonaws.com left intact"
  ],
  "rasterio": [
    "Entering env context: <rasterio.env.Env object at 0x143524490>",
    "Starting outermost env",
    "No GDAL environment exists",
    "New GDAL environment <rasterio._env.GDALEnv object at 0x143524670> created",
    "Installing FilePath filesystem handler plugin...",
    "GDAL_DATA found in environment.",
    "PROJ_LIB found in environment.",
    "Started GDALEnv: self=<rasterio._env.GDALEnv object at 0x143524670>.",
    "Entered env context: <rasterio.env.Env object at 0x143524490>",
    "Got a copy of environment <rasterio._env.GDALEnv object at 0x143524670> options",
    "Entering env context: <rasterio.env.Env object at 0x14355d6a0>",
    "Got a copy of environment <rasterio._env.GDALEnv object at 0x143524670> options",
    "Entered env context: <rasterio.env.Env object at 0x14355d6a0>",
    "Sharing flag: 0",
    "CPLE_None in [Fri Jun  2 18:44:50 2023].8553, 0.0000: HTTP: libcurl/7.87.0 (SecureTransport) LibreSSL/3.3.6 zlib/1.2.11 nghttp2/1.51.0",
    "CPLE_None in [Fri Jun  2 18:44:50 2023].8554, 0.0000: HTTP: GDAL was built against curl 7.77.0, but is running against 7.87.0.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].4615, 0.6062: VSICURL: GetFileSize(https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif)=119799105  response_code=200",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].4621, 0.6068: VSICURL: Downloading 0-32767 (https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif)...",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].6993, 0.8440: VSICURL: Got response_code=206",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7003, 0.8450: GDAL: GDALOpen(/vsicurl/https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif, this=0x149005730) succeeds as GTiff.",
    "Nodata success: 0, Nodata value: 0.000000",
    "Nodata success: 0, Nodata value: 0.000000",
    "Nodata success: 0, Nodata value: 0.000000",
    "Nodata success: 0, Nodata value: 0.000000",
    "Dataset <open DatasetReader name='https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif' mode='r'> is started.",
    "Exiting env context: <rasterio.env.Env object at 0x14355d6a0>",
    "Cleared existing <rasterio._env.GDALEnv object at 0x143524670> options",
    "Stopped GDALEnv <rasterio._env.GDALEnv object at 0x143524670>.",
    "No GDAL environment exists",
    "New GDAL environment <rasterio._env.GDALEnv object at 0x143524670> created",
    "GDAL_DATA found in environment.",
    "PROJ_LIB found in environment.",
    "Started GDALEnv: self=<rasterio._env.GDALEnv object at 0x143524670>.",
    "Exited env context: <rasterio.env.Env object at 0x14355d6a0>",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7259, 0.8706: GTiff: ScanDirectories()",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7262, 0.8708: GTiff: Opened 2824x2824 overview.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7264, 0.8710: GTiff: Opened 1412x1412 overview.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7266, 0.8712: GTiff: Opened 706x706 overview.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7267, 0.8714: GTiff: Opened 353x353 overview.",
    "Matched. confidence=100, c_code=b'3857', c_name=b'EPSG'",
    "Matched. confidence=100, c_code=b'4326', c_name=b'EPSG'",
    "Matched. confidence=100, c_code=b'3857', c_name=b'EPSG'",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7334, 0.8780: VRT: No valid sources found for band in VRT file ",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7334, 0.8781: GDAL: GDALOpen(<VRTDataset rasterYSize=\"5649\" rasterXSize=\"5649\"><VRTRasterBand /><SRS>GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]</SRS><GeoTransform>-79.8626,2.248185519560147e-06,0.0,32.8501,0.0,-2.248185519560147e-06</GeoTransform></VRTDataset>, this=0x1436174f0) succeeds as VRT.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7367, 0.8814: GDAL: Computing area of interest: -79.8626, 32.8374, -79.8499, 32.8501",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7370, 0.8817: OGRCT: Wrap source at -79.8563.",
    "Created exact transformer",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7379, 0.8826: GDAL: GDALClose(<VRTDataset rasterYSize=\"5649\" rasterXSize=\"5649\"><VRTRasterBand /><SRS>GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AXIS[\"Latitude\",NORTH],AXIS[\"Longitude\",EAST],AUTHORITY[\"EPSG\",\"4326\"]]</SRS><GeoTransform>-79.8626,2.248185519560147e-06,0.0,32.8501,0.0,-2.248185519560147e-06</GeoTransform></VRTDataset>, this=0x1436174f0)",
    "Exported CRS to WKT.",
    "Warp_extras: {'init_dest': 'NO_DATA'}",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7389, 0.8835: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7389, 0.8836: WARP: SetAlphaMax: AlphaMax not set.",
    "Nodata success: 0, Nodata value: -10000.000000",
    "Nodata success: 0, Nodata value: -10000.000000",
    "Nodata success: 0, Nodata value: -10000.000000",
    "Nodata success: 0, Nodata value: -10000.000000",
    "Dataset <closed WarpedVRT name='WarpedVRT(https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif)' mode='r'> is started.",
    "Output nodata value read from file: None",
    "Output nodata value read from file: None",
    "Output nodata value read from file: None",
    "Output nodata value read from file: None",
    "Output nodata values: [None, None, None, None]",
    "all_valid: False",
    "mask_flags: ([<MaskFlags.per_dataset: 2>, <MaskFlags.alpha: 4>], [<MaskFlags.per_dataset: 2>, <MaskFlags.alpha: 4>], [<MaskFlags.per_dataset: 2>, <MaskFlags.alpha: 4>], [<MaskFlags.all_valid: 1>])",
    "Jump straight to _read()",
    "Window: None",
    "IO window xoff=0.0 yoff=0.0 width=4446.0 height=4446.0",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7412, 0.8859: GDAL: GDALOverviewDataset(/vsicurl/https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif, this=0x149232500) creation.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7419, 0.8866: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7419, 0.8866: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7426, 0.8872: GDAL: GDALOverviewDataset(/vsicurl/https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif, this=0x14923bac0) creation.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7431, 0.8878: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7432, 0.8878: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7438, 0.8885: GDAL: GDALOverviewDataset(/vsicurl/https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif, this=0x14923b2b0) creation.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7443, 0.8890: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7444, 0.8890: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7450, 0.8897: GDAL: GDALOverviewDataset(/vsicurl/https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif, this=0x1431db080) creation.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7455, 0.8902: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7456, 0.8902: WARP: SetAlphaMax: AlphaMax not set.",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7462, 0.8908: GDAL: GDAL_CACHEMAX = 12288 MB",
    "CPLE_None in [Fri Jun  2 18:44:51 2023].7463, 0.8910: VSICURL: Downloading 32768-409599 (https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif)...",
    "CPLE_None in [Fri Jun  2 18:44:52 2023].1878, 1.3325: VSICURL: Got response_code=206",
    "CPLE_None in [Fri Jun  2 18:44:52 2023].1955, 1.3401: GDAL: GDALWarpKernel()::GWKNearestNoMasksOrDstDensityOnlyByte() Src=0,0,83x68 Dst=0,0,278x128",
    "CPLE_None in [Fri Jun  2 18:44:52 2023].1965, 1.3412: GDAL: GDALWarpKernel()::GWKNearestNoMasksOrDstDensityOnlyByte() Src=0,67,83x120 Dst=0,128,278x128",
    "CPLE_None in [Fri Jun  2 18:44:52 2023].1974, 1.3421: GDAL: GDALWarpKernel()::GWKNearestNoMasksOrDstDensityOnlyByte() Src=0,186,83x21 Dst=0,256,278x22",
    "CPLE_None in [Fri Jun  2 18:44:52 2023].2021, 1.3467: GDAL: GDALClose(/vsicurl/https://noaa-eri-pds.s3.amazonaws.com/2022_Hurricane_Ian/20221002a_RGB/20221002aC0795145w325100n.tif, this=0x149005730)",
    "Exiting env context: <rasterio.env.Env object at 0x143524490>",
    "Cleared existing <rasterio._env.GDALEnv object at 0x143524670> options",
    "Stopped GDALEnv <rasterio._env.GDALEnv object at 0x143524670>.",
    "Exiting outermost env",
    "Exited env context: <rasterio.env.Env object at 0x143524490>"
  ]
}
```